### PR TITLE
Update README validator URL

### DIFF
--- a/src/commands/validate-readme-txt.js
+++ b/src/commands/validate-readme-txt.js
@@ -22,7 +22,7 @@ export default () => {
 
 function validate( readme, cb ) {
 	const options = {
-		url: 'https://wordpress.org/plugins/about/validator/',
+		url: 'https://wordpress.org/plugins/developers/readme-validator/',
 		form: {
 			readme_contents: readme, // eslint-disable-line camelcase
 			text: '1',


### PR DESCRIPTION
Currently the variable for README validator URL has been outdated. It will send response 302 when try to validate README file.